### PR TITLE
fix: Prevent LLMs from mentioning themselves

### DIFF
--- a/src/event_handlers/on_message.py
+++ b/src/event_handlers/on_message.py
@@ -85,7 +85,7 @@ async def on_message(message: discord.Message):
             webhook = await llm_service.get_or_create_webhook(llm, channel)
             if replied_to_webhook_id and replied_to_webhook_id == webhook.id:
                 pinged_llms.add(llm)
-            if llm_service.mentioned_in_message(llm, message):
+            if await llm_service.mentioned_in_message(llm, message):
                 pinged_llms.add(llm)
                 logger.info(f"Pinged {llm.name}")
 

--- a/src/services/llm.py
+++ b/src/services/llm.py
@@ -371,8 +371,13 @@ class LLMService:
         except Exception as e:
             logger.exception(f"Error in respond method: {str(e)}")
 
-    @staticmethod
-    def mentioned_in_message(llm: LLM, message: discord.Message) -> bool:
+    async def mentioned_in_message(self, llm: LLM, message: discord.Message) -> bool:
+        # Self-mentions don't count
+        webhook_service = WebhookService(session=self.session)
+        webhook = await webhook_service.get(message.webhook_id)
+        if webhook and webhook.llm_id == llm.id:
+            return False
+
         mentioned = f"@{llm.name.lower()}" in message.content.lower()
         return mentioned
 


### PR DESCRIPTION
LLMs are capable of mentioning themselves and getting stuck in infinite loops. This change prevents this from occurring by ignoring self-mentions.

Fixes #24